### PR TITLE
Fix issue where we couldn't compile with optimizations on

### DIFF
--- a/AICamera-ObjC/AICamera-ObjC/ViewController.mm
+++ b/AICamera-ObjC/AICamera-ObjC/ViewController.mm
@@ -59,15 +59,14 @@
             self.sampleImageView.image = image;
         }
     });
-    __block NSString* content = @"";
-    __weak typeof(self) weakSelf = self;
     [self.modelManager predict:tensor
                     completion:^(std::vector<std::tuple<float, std::string>>&& results) {
+        NSString* content = @"";
         for(auto& result: results){
             NSString* str = [NSString stringWithFormat:@"score: %.3f, label: %s \n", std::get<0>(result), std::get<1>(result).c_str()];
             content = [content stringByAppendingString:str];
             dispatch_async(dispatch_get_main_queue(), ^{
-                weakSelf.resultView.text = content;
+                self.resultView.text = content;
             });
         }
     }];


### PR DESCRIPTION
With this fix, now we can compile with -Os.

This doesn't really affect the size though (still 38MB on -O0 vs. -Os) because most of the app size comes from libtorch.